### PR TITLE
Fix critical System.Drawing.Common vulnerability

### DIFF
--- a/advancement-chart.tests/advancement-chart.tests.csproj
+++ b/advancement-chart.tests/advancement-chart.tests.csproj
@@ -5,6 +5,9 @@
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="3.2.0">
@@ -25,7 +28,7 @@
   <!-- Copy libgdiplus native library for EPPlus AutoFitColumns support on macOS -->
   <Target Name="CopyLibGdiPlus" AfterTargets="Build" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
     <Copy SourceFiles="/opt/homebrew/lib/libgdiplus.dylib"
-          DestinationFolder="$(OutputPath)runtimes/unix/lib/netcoreapp3.0/"
-          Condition="Exists('/opt/homebrew/lib/libgdiplus.dylib') And !Exists('$(OutputPath)runtimes/unix/lib/netcoreapp3.0/libgdiplus.dylib')" />
+          DestinationFolder="$(OutputPath)runtimes/unix/lib/net6.0/"
+          Condition="Exists('/opt/homebrew/lib/libgdiplus.dylib') And !Exists('$(OutputPath)runtimes/unix/lib/net6.0/libgdiplus.dylib')" />
   </Target>
 </Project>

--- a/advancement-chart/advancement-chart.csproj
+++ b/advancement-chart/advancement-chart.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />
+  </ItemGroup>
+  <ItemGroup>
     <Folder Include="Model\"/>
     <Folder Include="Model\Ranks\"/>
     <Folder Include="Reports\"/>
@@ -14,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.1.1"/>
     <PackageReference Include="EPPlus" Version="5.7.3"/>
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2"/>
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0"/>
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.15.0"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Upgrades `System.Drawing.Common` from 5.0.2 to 6.0.0 to resolve [GHSA-rxg9-xrhp-64gj](https://github.com/advisories/GHSA-rxg9-xrhp-64gj) (critical severity)
- Adds `System.Drawing.EnableUnixSupport` runtime config option to both projects to maintain macOS/Linux compatibility with the 6.0 package
- Updates the test project's `CopyLibGdiPlus` target path from `netcoreapp3.0` to `net6.0` to match the new package's native library resolution path

## Test plan
- [x] All 383 tests pass
- [x] `dotnet list package --vulnerable` reports no vulnerabilities
- [x] Build succeeds with zero warnings

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)