### PR TITLE
Fix exception swallowing in LoadFile()

### DIFF
--- a/advancement-chart/Program.cs
+++ b/advancement-chart/Program.cs
@@ -104,6 +104,7 @@ namespace advancement_chart
         internal static DateTime LoadFile(string fileName, List<TroopMember> scouts)
         {
             DateTime result = DateTime.MinValue;
+            var warnings = new List<string>();
 
             if (File.Exists(fileName))
             {
@@ -252,14 +253,27 @@ namespace advancement_chart
                                     break;
                             }
                         }
-                        catch (Exception e)
+                        catch (FormatException e)
                         {
-                            Console.Error.WriteLine($"type: {type} subtype: {subtype} version: {version} date: {date.ToShortDateString()}");
-                            Console.Error.WriteLine($"{e}");
+                            warnings.Add($"Skipped row: type={type} subtype={subtype} version={version} date={date.ToShortDateString()} - {e.Message}");
+                        }
+                        catch (ArgumentException e)
+                        {
+                            warnings.Add($"Invalid data: type={type} subtype={subtype} version={version} date={date.ToShortDateString()} - {e.Message}");
                         }
                     }
                 }
             }
+
+            if (warnings.Count > 0)
+            {
+                Console.Error.WriteLine($"Warning: {warnings.Count} row(s) skipped while loading {fileName}:");
+                foreach (var warning in warnings)
+                {
+                    Console.Error.WriteLine($"  {warning}");
+                }
+            }
+
             return result;
         }
     }


### PR DESCRIPTION
## Summary
- Narrows the catch-all `Exception` handler in `LoadFile()` to only catch `FormatException` and `ArgumentException` (expected data parsing errors)
- Accumulates warnings and prints a summary to stderr after file loading completes, instead of logging each error inline
- Unexpected exceptions (e.g., `NullReferenceException`, `InvalidOperationException`) now propagate instead of being silently swallowed
- Adds 2 new tests validating warning output on malformed data and no warnings on valid data

## Test plan
- [x] All 385 tests pass (23 ProgramTest tests verified individually)
- [x] Build succeeds with zero warnings

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)