### PR TITLE
Warn when patrol lookup file is missing

### DIFF
--- a/advancement-chart/Program.cs
+++ b/advancement-chart/Program.cs
@@ -28,7 +28,14 @@ namespace advancement_chart
             // Download the "Scout" backup report from Scoutbook and rename
             // the file "scouts.csv"
             //
-            LoadPatrolLookup("./scouts.csv", scouts);
+            var patrolFile = "./scouts.csv";
+            if (!File.Exists(patrolFile))
+            {
+                Console.Error.WriteLine($"WARNING: Patrol lookup file '{patrolFile}' not found.");
+                Console.Error.WriteLine("Scouts will not have patrol assignments, nicknames, or dates of birth.");
+                Console.Error.WriteLine("Eagle Report deadline calculations will be incorrect.");
+            }
+            LoadPatrolLookup(patrolFile, scouts);
             {
                 var report = new TroopReport(scouts);
                 report.Run(@"./TroopAdvancementChart.xlsx");


### PR DESCRIPTION
## Summary
- Adds a file existence check in `Main()` before calling `LoadPatrolLookup()`
- Prints a clear warning to stderr when `scouts.csv` is not found, explaining that patrol assignments, nicknames, dates of birth, and Eagle Report deadline calculations will be affected
- No behavior change — `LoadPatrolLookup()` already silently skips when the file is missing; this just makes the user aware

## Test plan
- [x] All 23 ProgramTest tests pass
- [x] Build succeeds with zero warnings

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)