### PR TITLE
Add date-of-birth validation in LoadPatrolLookup()

### DIFF
--- a/advancement-chart.tests/ProgramTest.cs
+++ b/advancement-chart.tests/ProgramTest.cs
@@ -380,5 +380,80 @@ namespace advancement_chart.tests
 
             Assert.Empty(errWriter.ToString());
         }
+
+        [Fact]
+        public void LoadPatrolLookup_FutureDob_WarnsButStillSets()
+        {
+            _scouts.Add(new TroopMember("123", "John", "", "Doe"));
+
+            string csv = "BSA Member ID,Nickname,Patrol Name,DOB\n" +
+                          "123,Johnny,Hawks,2030-01-01";
+            var path = CreateTempCsv(csv);
+
+            var oldErr = Console.Error;
+            var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+            try
+            {
+                Program.LoadPatrolLookup(path, _scouts);
+            }
+            finally
+            {
+                Console.SetError(oldErr);
+            }
+
+            Assert.Equal(new DateTime(2030, 1, 1), _scouts[0].DateOfBirth);
+            Assert.Contains("Suspicious DOB", errWriter.ToString());
+        }
+
+        [Fact]
+        public void LoadPatrolLookup_AncientDob_WarnsButStillSets()
+        {
+            _scouts.Add(new TroopMember("123", "John", "", "Doe"));
+
+            string csv = "BSA Member ID,Nickname,Patrol Name,DOB\n" +
+                          "123,Johnny,Hawks,1980-01-01";
+            var path = CreateTempCsv(csv);
+
+            var oldErr = Console.Error;
+            var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+            try
+            {
+                Program.LoadPatrolLookup(path, _scouts);
+            }
+            finally
+            {
+                Console.SetError(oldErr);
+            }
+
+            Assert.Equal(new DateTime(1980, 1, 1), _scouts[0].DateOfBirth);
+            Assert.Contains("Suspicious DOB", errWriter.ToString());
+        }
+
+        [Fact]
+        public void LoadPatrolLookup_ValidDob_NoWarning()
+        {
+            _scouts.Add(new TroopMember("123", "John", "", "Doe"));
+
+            string csv = "BSA Member ID,Nickname,Patrol Name,DOB\n" +
+                          "123,Johnny,Hawks,2010-06-15";
+            var path = CreateTempCsv(csv);
+
+            var oldErr = Console.Error;
+            var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+            try
+            {
+                Program.LoadPatrolLookup(path, _scouts);
+            }
+            finally
+            {
+                Console.SetError(oldErr);
+            }
+
+            Assert.Equal(new DateTime(2010, 6, 15), _scouts[0].DateOfBirth);
+            Assert.DoesNotContain("Suspicious", errWriter.ToString());
+        }
     }
 }

--- a/advancement-chart/Program.cs
+++ b/advancement-chart/Program.cs
@@ -99,6 +99,10 @@ namespace advancement_chart
                                 DateTime dobDate;
                                 if (DateTime.TryParse(dob, out dobDate))
                                 {
+                                    if (dobDate.Year < 1990 || dobDate > DateTime.Now)
+                                    {
+                                        Console.Error.WriteLine($"WARNING: Suspicious DOB '{dob}' for {scout.DisplayName}");
+                                    }
                                     scout.DateOfBirth = dobDate;
                                 }
                             }


### PR DESCRIPTION
## Summary
- Adds bounds checking for DOB values parsed in `LoadPatrolLookup()` — warns on dates before 1990 or in the future
- DOB is still set so processing continues, but user is alerted to potential data issues via stderr
- Adds 3 new tests: future DOB warns, ancient DOB warns, valid DOB no warning

## Test plan
- [x] All 26 ProgramTest tests pass
- [x] Build succeeds with zero warnings

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)