### PR TITLE
Fix palm ordinal validation and empty list crash in GetNthPalm()

### DIFF
--- a/advancement-chart.tests/Model/TroopMemberTest.cs
+++ b/advancement-chart.tests/Model/TroopMemberTest.cs
@@ -226,6 +226,40 @@ namespace advancement_chart.tests.Model
         }
 
         [Fact]
+        public void GetNthPalm_ZeroOrdinal_Throws()
+        {
+            var scout = TestFixtures.CreateScoutWithAllRanksEarned();
+            Assert.Throws<ArgumentOutOfRangeException>(() => scout.GetNthPalm(Palm.PalmType.Bronze, 0));
+        }
+
+        [Fact]
+        public void GetNthPalm_NegativeOrdinal_Throws()
+        {
+            var scout = TestFixtures.CreateScoutWithAllRanksEarned();
+            Assert.Throws<ArgumentOutOfRangeException>(() => scout.GetNthPalm(Palm.PalmType.Bronze, -1));
+        }
+
+        [Fact]
+        public void GetNthPalm_EmptyList_CreatesBronze()
+        {
+            var scout = TestFixtures.CreateScoutWithAllRanksEarned();
+            var bronze = scout.GetNthPalm(Palm.PalmType.Bronze, 1);
+            Assert.NotNull(bronze);
+            Assert.Equal(Palm.PalmType.Bronze, bronze.Type);
+            Assert.Single(scout.EaglePalms);
+        }
+
+        [Fact]
+        public void GetNthPalm_EmptyList_GoldReturnsNull()
+        {
+            var scout = TestFixtures.CreateScoutWithAllRanksEarned();
+            // Gold can't be the first palm — must start with Bronze
+            var result = scout.GetNthPalm(Palm.PalmType.Gold, 1);
+            Assert.Null(result);
+            Assert.Empty(scout.EaglePalms);
+        }
+
+        [Fact]
         public void Add_NewBadge_AddsToList()
         {
             var scout = TestFixtures.CreateScout();

--- a/advancement-chart/Model/TroopMember.cs
+++ b/advancement-chart/Model/TroopMember.cs
@@ -97,6 +97,9 @@ namespace advancementchart.Model
         /// next available.
         public Palm GetNthPalm(Palm.PalmType type, int ordinal = 1)
         {
+            if (ordinal <= 0)
+                throw new ArgumentOutOfRangeException(nameof(ordinal), "Ordinal must be positive.");
+
             var palmsOfType = this.EaglePalms.Where(x => x.Type == type);
             if (palmsOfType.Count() >= ordinal)
             {
@@ -104,12 +107,21 @@ namespace advancementchart.Model
             }
             else if (palmsOfType.Count() == ordinal - 1)
             {
-                Palm lastPalm = this.EaglePalms.Last();
-                if (
-                    (type == Palm.PalmType.Bronze && lastPalm.Type == Palm.PalmType.Silver)
-                    || (type == Palm.PalmType.Gold && lastPalm.Type == Palm.PalmType.Bronze)
-                    || (type == Palm.PalmType.Silver && lastPalm.Type == Palm.PalmType.Gold)
-                )
+                bool canCreate;
+                if (!this.EaglePalms.Any())
+                {
+                    // First palm must be Bronze
+                    canCreate = type == Palm.PalmType.Bronze;
+                }
+                else
+                {
+                    Palm lastPalm = this.EaglePalms.Last();
+                    canCreate =
+                        (type == Palm.PalmType.Bronze && lastPalm.Type == Palm.PalmType.Silver)
+                        || (type == Palm.PalmType.Gold && lastPalm.Type == Palm.PalmType.Bronze)
+                        || (type == Palm.PalmType.Silver && lastPalm.Type == Palm.PalmType.Gold);
+                }
+                if (canCreate)
                 {
                     Palm palm = new Palm(type);
                     this.EaglePalms.Add(palm);


### PR DESCRIPTION
## Summary
- Adds `ArgumentOutOfRangeException` for non-positive ordinal values
- Fixes a crash (`InvalidOperationException`) when `EaglePalms` is empty — previously called `.Last()` on an empty list when creating the first palm
- Handles the empty list case correctly: only Bronze can be the first palm; Gold/Silver return null
- Adds 4 new tests: zero ordinal throws, negative ordinal throws, empty list creates Bronze, empty list rejects Gold

## Test plan
- [x] All 58 TroopMemberTest tests pass
- [x] All related test classes (ProgramTest, TroopReportTest, EagleReportTest) pass
- [x] Build succeeds with zero warnings

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)