### PR TITLE
Refactor: Extract Eagle equivalency rules into single source of truth

### DIFF
--- a/advancement-chart/Model/EagleMeritBadgeRequirement.cs
+++ b/advancement-chart/Model/EagleMeritBadgeRequirement.cs
@@ -29,35 +29,11 @@ namespace advancementchart.Model
         {
             if (badge.EagleRequired)
             {
-                // (a) First Aid
-                // (b) Citizenship in the Community
-                // (c) Citizenship in the Nation
-                // (d) Citizenship in the World
-                // (e) Communication
-                // (f) Cooking
-                // (g) Personal Fitness
-                // (h) Emergency Preparedness or Lifesaving
-                if ((badge.Name == "Emergency Preparedness" && MeritBadges.Any(mb => mb.Name == "Lifesaving"))
-                    || (badge.Name == "Lifesaving" && MeritBadges.Any(mb => mb.Name == "Emergency Preparedness")))
+                var equivalents = MeritBadge.GetEagleEquivalents(badge.Name);
+                if (equivalents.Length > 0 && MeritBadges.Any(mb => equivalents.Contains(mb.Name)))
                 {
                     return false;
                 }
-                // (i) Environmental Science or Sustainability
-                if ((badge.Name == "Environmental Science" && MeritBadges.Any(mb => mb.Name == "Sustainability"))
-                    || (badge.Name == "Sustainability" && MeritBadges.Any(mb => mb.Name == "Environmental Science")))
-                {
-                    return false;
-                }
-                // (j) Personal Management
-                // (k) Swimming or Hiking or Cycling
-                if ((badge.Name == "Swimming" && MeritBadges.Any(mb => mb.Name == "Hiking" || mb.Name == "Cycling"))
-                    || (badge.Name == "Hiking" && MeritBadges.Any(mb => mb.Name == "Swimming" || mb.Name == "Cycling"))
-                    || (badge.Name == "Cycling" && MeritBadges.Any(mb => mb.Name == "Swimming" || mb.Name == "Hiking")))
-                {
-                    return false;
-                }
-                // (l) Camping
-                // (m) Family Life
             }
             return base.Add(badge, false);
         }

--- a/advancement-chart/Model/MeritBadge.cs
+++ b/advancement-chart/Model/MeritBadge.cs
@@ -8,73 +8,28 @@ namespace advancementchart.Model
     {
         public static IEnumerable<MeritBadge> GetEagleEquivalents(this IEnumerable<MeritBadge> list, string badgeName)
         {
-            if (badgeName == "Emergency Preparedness")
-            {
-                return list.Where(x => x.Name == "Lifesaving");
-            }
-            else if (badgeName == "Lifesaving")
-            {
-                return list.Where(x => x.Name == "Emergency Preparedness");
-            }
-            else if (badgeName == "Environmental Science")
-            {
-                return list.Where(x => x.Name == "Sustainability");
-            }
-            else if (badgeName == "Sustainability")
-            {
-                return list.Where(x => x.Name == "Environmental Science");
-            }
-            else if (badgeName == "Swimming")
-            {
-                return list.Where(x => x.Name == "Hiking" || x.Name == "Cycling");
-            }
-            else if (badgeName == "Hiking")
-            {
-                return list.Where(x => x.Name == "Swimming" || x.Name == "Cycling");
-            }
-            else if (badgeName == "Cycling")
-            {
-                return list.Where(x => x.Name == "Swimming" || x.Name == "Hiking");
-            }
-            else
-            {
-                return list.Where(x => false);
-            }
+            var equivalents = MeritBadge.GetEagleEquivalents(badgeName);
+            return list.Where(x => equivalents.Contains(x.Name));
         }
     }
 
     public class MeritBadge : BaseEntity
     {
+        public static readonly string[][] MutuallyExclusiveGroups = new[]
+        {
+            new[] { "Emergency Preparedness", "Lifesaving" },
+            new[] { "Environmental Science", "Sustainability" },
+            new[] { "Swimming", "Hiking", "Cycling" }
+        };
 
         static public string[] GetEagleEquivalents(string badgeName)
         {
-            if (badgeName == "Environmental Science")
+            foreach (var group in MutuallyExclusiveGroups)
             {
-                return new string[] { "Sustainability" };
-            }
-            else if (badgeName == "Sustainability")
-            {
-                return new string[] { "Environmental Science" };
-            }
-            else if (badgeName == "Lifesaving")
-            {
-                return new string[] { "Emergency Preparedness" };
-            }
-            else if (badgeName == "Emergency Preparedness")
-            {
-                return new string[] { "Lifesaving" };
-            }
-            else if (badgeName == "Swimming")
-            {
-                return new string[] { "Hiking", "Cycling" };
-            }
-            else if (badgeName == "Hiking")
-            {
-                return new string[] { "Swimming", "Cycling" };
-            }
-            else if (badgeName == "Cycling")
-            {
-                return new string[] { "Swimming", "Hiking" };
+                if (group.Contains(badgeName))
+                {
+                    return group.Where(name => name != badgeName).ToArray();
+                }
             }
 
             return new string[] { };
@@ -82,13 +37,7 @@ namespace advancementchart.Model
 
         static public bool IsMultiple(string badgeName)
         {
-            return badgeName == "Lifesaving" ||
-                badgeName == "Emergency Preparedness" ||
-                badgeName == "Environmental Science" ||
-                badgeName == "Sustainability" ||
-                badgeName == "Swimming" ||
-                badgeName == "Hiking" ||
-                badgeName == "Cycling";
+            return MutuallyExclusiveGroups.Any(group => group.Contains(badgeName));
         }
 
         static public bool IsMultiple(MeritBadge badge)


### PR DESCRIPTION
## Summary
- Add `MutuallyExclusiveGroups` static field to `MeritBadge` as the single source of truth for mutually exclusive Eagle merit badge groups (EP/LS, ES/SB, SW/HK/CY)
- Refactor `GetEagleEquivalents()`, `IsMultiple()`, and `EagleMeritBadgeRequirement.Add()` to derive behavior from this data structure instead of hardcoded if/else chains
- Net reduction of 75 lines by eliminating duplication across 4 locations

## Test plan
- [x] All 343 existing tests pass unchanged — pure refactoring with no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)