### PR TITLE
Update outdated .NET framework references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Class and a Trail to Eagle report for each Scout at or over First Class.
 1. Make sure you have the code checked out.
 1. Fetch NuGet dependencies; while in the checked-out code directory: `dotnet restore`
 1. Build the code; while in the checked-out code directory: `dotnet build`
-1. Assuming the code built, you would execute it as: `dotnet /path/to/advancement-chart/advancement-chart/bin/Debug/netcoreapp2.0/advancement-chart.dll`
+1. Assuming the code built, you would execute it as: `dotnet /path/to/advancement-chart/advancement-chart/bin/Debug/net8.0/advancement-chart.dll`
 
 ## RUNNING
 
@@ -24,7 +24,7 @@ names or patrols change, or when a Scout joins or leaves the Troop.
 1. Also on the `Export/Backup` link, choose `Scout Advancement` and download
 that `troop_#####__advancement.csv` file to your computer.
 1. With the `scouts.csv` and the `troop_#####__advancement.csv` files in the same
-directory, run the `advancement-chart` program: `dotnet /path/to/advancement-chart/advancement-chart/bin/Debug/netcoreapp2.0/advancement-chart.dll troop_#####__advancement.csv`.
+directory, run the `advancement-chart` program: `dotnet /path/to/advancement-chart/advancement-chart/bin/Debug/net8.0/advancement-chart.dll troop_#####__advancement.csv`.
 1. This will create three files:
    1. TroopAdvancementChart.xlsx - this is an Excel workbook with three
    worksheets:
@@ -80,7 +80,7 @@ if [ ! -f "${1}" ]; then
 	echo
 	exit 1
 fi
-dotnet /path/to/advancement-chart/advancement-chart/bin/Debug/netcoreapp2.0/advancement-chart.dll ${1}
+dotnet /path/to/advancement-chart/advancement-chart/bin/Debug/net8.0/advancement-chart.dll ${1}
 ```
 
 Don't forget to set that script as executable: `chmod 755 /usr/local/sbin/advancement-chart`

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -29,7 +29,7 @@ advancement.csv : troop_201_B__advancement.csv troop_201_G__advancement.csv
 	for i in $^; do tail -n +2 $$i >> $@; done
 
 EagleReport.xlsx TroopAdvancementChart.xlsx IndividualReport.xlsx TroopGuideReport.xlsx AdvancementReport.docx : advancement.csv scouts.csv
-	dotnet $$HOME/src/advancement-chart/advancement-chart/bin/Debug/net7.0/advancement-chart.dll $<
+	dotnet $$HOME/src/advancement-chart/advancement-chart/bin/Debug/net8.0/advancement-chart.dll $<
 	cp -f $^ ~/Dropbox/Scouts/Troop\ Committee/
 
 clean :


### PR DESCRIPTION
## Summary
- Update README.md references from `netcoreapp2.0` to `net8.0` (3 occurrences)
- Update `utils/Makefile` reference from `net7.0` to `net8.0`

Closes #23

## Test plan
- [ ] Verify README paths match actual build output directory
- [ ] Verify Makefile runs against correct framework directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)