### PR TITLE
Remove dead and commented-out code

### DIFF
--- a/advancement-chart/Model/Ranks/Scout.cs
+++ b/advancement-chart/Model/Ranks/Scout.cs
@@ -14,7 +14,6 @@ namespace advancementchart.Model.Ranks
             Requirements.Add(new RankRequirement(name: "1d", description: "Describe First Class badge", rank: this, handbookPages: "19-20", curriculumGroup: CurriculumGroup.FormingThePatrol));
             Requirements.Add(new RankRequirement(name: "1e", description: "Repeat and explain Outdoor Code", rank: this, handbookPages: "223-224", curriculumGroup: CurriculumGroup.FormingThePatrol));
             Requirements.Add(new RankRequirement(name: "1f", description: "Repeat Pledge of Allegiance", rank: this, handbookPages: "60", curriculumGroup: CurriculumGroup.FormingThePatrol));
-            //Requirements.Add(new RankRequirement(name: "2", description: "After attending at least one meeting", rank: this, handbookPages: "", curriculumGroup: CurriculumGroup.FormingThePatrol));
             Requirements.Add(new RankRequirement(name: "2a", description: "Describe how Scouts provide leadership", rank: this, handbookPages: "24,32-33,42-43,420-423", curriculumGroup: CurriculumGroup.FormingThePatrol));
             Requirements.Add(new RankRequirement(name: "2b", description: "Describe four steps of advancement", rank: this, handbookPages: "412-415", curriculumGroup: CurriculumGroup.FormingThePatrol));
             Requirements.Add(new RankRequirement(name: "2c", description: "Describe Scout ranks and process", rank: this, handbookPages: "27-28,439-452", curriculumGroup: CurriculumGroup.FormingThePatrol));
@@ -24,7 +23,6 @@ namespace advancementchart.Model.Ranks
             Requirements.Add(new RankRequirement(name: "4a", description: "Tie square knot, two half-hitches, and taughtline hitch", rank: this, handbookPages: "364-367", curriculumGroup: CurriculumGroup.KnotsAndLashings1));
             Requirements.Add(new RankRequirement(name: "4b", description: "Whip and fuse rope", rank: this, handbookPages: "360-362", curriculumGroup: CurriculumGroup.KnotsAndLashings1));
             Requirements.Add(new RankRequirement(name: "5", description: "Demonstrate pocketknife safety", rank: this, handbookPages: "379-381", curriculumGroup: CurriculumGroup.TotinChip));
-            //Requirements.Add(new RankRequirement(name: "6", description: "Personal protection", rank: this, handbookPages: "407-409"));
             Requirements.Add(new RankRequirement(name: "6a", description: "Complete abuse packet with parent", rank: this, handbookPages: ""));
             Requirements.Add(new RankRequirement(name: "6b", description: "Earn cyber chip", rank: this, handbookPages: ""));
             Requirements.Add(new RankRequirement(name: "7", description: "Scoutmaster conference", rank: this, handbookPages: ""));

--- a/advancement-chart/Model/TroopMember.cs
+++ b/advancement-chart/Model/TroopMember.cs
@@ -169,7 +169,6 @@ namespace advancementchart.Model
         {
             if (!MeritBadges.Any(x => x.Name == badge.Name))
             {
-                // Console.WriteLine($"{DisplayName}: Adding {(badge.Earned ? "completed" : "partial")} {badge.Name} to {String.Join(", ", MeritBadges.Select(x => x.Name))}");
                 MeritBadges.Add(badge);
             }
             else
@@ -177,7 +176,6 @@ namespace advancementchart.Model
                 var existing = MeritBadges.First(x => x.Name == badge.Name);
                 if (!existing.Earned && badge.Earned)
                 {
-                    // Console.WriteLine($"{DisplayName}: Removing partial {existing.Name} to add completed {badge.Name} to {String.Join(", ", MeritBadges.Select(x => x.Name))}");
                     MeritBadges.Remove(existing);
                     MeritBadges.Add(badge);
                 }
@@ -188,7 +186,6 @@ namespace advancementchart.Model
         {
             if (!MeritBadges.Any(x => x.Name == badgeName))
             {
-                // Console.WriteLine($"{DisplayName}: Adding partial {badgeName} to {String.Join(", ", MeritBadges.Select(x => x.Name))}");
                 MeritBadge partial = new MeritBadge(name: badgeName, description: version, earned: null);
                 partial.Started = true;
                 this.Add(partial);
@@ -208,22 +205,18 @@ namespace advancementchart.Model
                 if (!Star.MbReq.Earned)
                 {
                     added = Star.MbReq.Add(badge);
-                    // Console.WriteLine($"[{DisplayName}] {badge.Name} was{(added ? "" : " not")} added to Star");
                 }
                 if (!added && !Life.MbReq.Earned)
                 {
                     added = Life.MbReq.Add(badge);
-                    // Console.WriteLine($"[{DisplayName}] {badge.Name} was{(added ? "" : " not")} added to Life");
                 }
                 if (!added && !Star.MbReq.Earned)
                 {
                     added = Star.MbReq.AddAny(badge);
-                    // Console.WriteLine($"[{DisplayName}] {badge.Name} was{(added ? "" : " not")} added to Star as Elective");
                 }
                 if (!added && !Life.MbReq.Earned)
                 {
                     added = Life.MbReq.AddAny(badge);
-                    // Console.WriteLine($"[{DisplayName}] {badge.Name} was{(added ? "" : " not")} added to Life as Elective");
                 }
 
                 bool eagleAdded = false;

--- a/advancement-chart/Reports/AdvancementReport.cs
+++ b/advancement-chart/Reports/AdvancementReport.cs
@@ -200,14 +200,12 @@ namespace advancementchart.Reports
                                 {
                                     if (skip.Any(x => x == badgeName))
                                     {
-                                        // Console.WriteLine($"Skip {badgeName}");
                                         continue;
                                     }
                                     skip.Add(badgeName);
                                     bool haveStarted = mbReq.MeritBadges.Any(x => x.Name == badgeName && !x.Earned);
                                     IEnumerable<MeritBadge> others = mbReq.MeritBadges.GetEagleEquivalents(badgeName);
                                     bool isMultiple = MeritBadge.IsMultiple(badgeName);
-                                    // Console.WriteLine($"{badgeName} isMultiple {isMultiple}");
                                     bool haveEarnedOther = others.Any(x => x.Earned);
                                     bool haveStartedOther = others.Any(x => x.Started);
 
@@ -271,7 +269,6 @@ namespace advancementchart.Reports
                             {
                                 MeritBadgeRequirement mbReq = requirement as MeritBadgeRequirement;
                                 WriteLine(body: body, line: $"=> {mbReq.MeritBadges.Where(x => x.Earned).Count()} of {mbReq.Total} earned.", indent: true);
-                                // Console.WriteLine($"[{scout.DisplayName}] {String.Join(", ", mbReq.MeritBadges.Select(x => x.Name))}");
                                 foreach (var mb in mbReq.MeritBadges.Where(x => x.Earned && x.EagleRequired))
                                 {
                                     WriteLine(body: body, line: $"Earned: {mb.Name} *", indent: true);

--- a/advancement-chart/Reports/TroopReport.cs
+++ b/advancement-chart/Reports/TroopReport.cs
@@ -222,7 +222,6 @@ namespace advancementchart.Reports
                 }
             }
             cell.ColumnNumber++;
-            //wks.Cells[cell].Value = $"{rank.Name} Earned";
             wks.Cells[cell].Value = "Earned";
             wks.Cells[cell].Style.HorizontalAlignment = OfficeOpenXml.Style.ExcelHorizontalAlignment.Right;
             wks.Cells[cell].Style.Font.Bold = true;
@@ -425,7 +424,6 @@ namespace advancementchart.Reports
                 else
                 {
                     cell.ColumnNumber++;
-                    //wks.Cells[cell].Value = req.Earned ? "X" : "";
                     wks.Cells[cell].Value = req.Earned ? "●" : "";
                     wks.Cells[cell].Style.HorizontalAlignment = OfficeOpenXml.Style.ExcelHorizontalAlignment.Center;
                 }
@@ -554,16 +552,12 @@ namespace advancementchart.Reports
 
                         scout.AllocateMeritBadges();
 
-                        //if (!scout.FirstClass.Earned)
-                        //{
                         ta.Cells[taCell].Value = $"   {scout.DisplayName}";
 
                         taCell = AddContent(ta, taCell, scout.Scout);
                         taCell = AddContent(ta, taCell, scout.Tenderfoot);
                         taCell = AddContent(ta, taCell, scout.SecondClass);
                         taCell = AddContent(ta, taCell, scout.FirstClass);
-                        //}
-                        //else
 
                         if (scout.FirstClass.Earned)
                         {
@@ -652,10 +646,6 @@ namespace advancementchart.Reports
                     sa.Cells[$"{a}:{b}"].Style.Border.BorderAround(OfficeOpenXml.Style.ExcelBorderStyle.Thick, Color.Black);
                 }
                 sa.Row(saHeaderRow).Style.Border.Bottom.Style = OfficeOpenXml.Style.ExcelBorderStyle.Thick;
-
-                /*mb.DefaultColWidth = 0.1;
-                mb.Calculate();
-                mb.Cells[mb.Dimension.Address].AutoFitColumns();*/
 
                 package.Save();
             }


### PR DESCRIPTION
## Summary
- Remove commented-out requirements in Scout.cs (old pre-split req 2 and 6)
- Remove debug `Console.WriteLine` statements in TroopMember.cs and AdvancementReport.cs
- Remove obsolete commented-out code in TroopReport.cs (old header label, X marker, if/else block, and mb formatting block)

Closes #16

## Test plan
- [x] `dotnet build` passes with 0 warnings, 0 errors
- [x] `dotnet test` passes all 349 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)