### PR TITLE
Adjust TroopCheckList layout and filter Inactive from all reports

### DIFF
--- a/advancement-chart.tests/Reports/TroopCheckListTest.cs
+++ b/advancement-chart.tests/Reports/TroopCheckListTest.cs
@@ -136,8 +136,8 @@ namespace advancement_chart.tests.Reports
                 Assert.Equal(OfficeOpenXml.Style.ExcelBorderStyle.Thin, border.Left.Style);
                 Assert.Equal(OfficeOpenXml.Style.ExcelBorderStyle.Thin, border.Right.Style);
 
-                // Column Z (26) should also have borders (verifying many checkbox columns exist)
-                var farBorder = wks.Cells[3, 26].Style.Border;
+                // Column K (11) should also have borders (last checkbox column)
+                var farBorder = wks.Cells[3, 11].Style.Border;
                 Assert.Equal(OfficeOpenXml.Style.ExcelBorderStyle.Thin, farBorder.Top.Style);
             }
         }
@@ -153,8 +153,8 @@ namespace advancement_chart.tests.Reports
             {
                 var wks = package.Workbook.Worksheets["Troop Checklist"];
 
-                // Header row should be 4x default height
-                Assert.Equal(wks.DefaultRowHeight * 4, wks.Row(1).Height);
+                // Header row should be 8x default height
+                Assert.Equal(wks.DefaultRowHeight * 8, wks.Row(1).Height);
 
                 // Header checkbox cells should have left, bottom, right borders but not top
                 var border = wks.Cells[1, 2].Style.Border;

--- a/advancement-chart/Reports/AdvancementCheck.cs
+++ b/advancement-chart/Reports/AdvancementCheck.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using advancementchart.Model;
 
 namespace advancementchart.Reports
@@ -16,7 +17,7 @@ namespace advancementchart.Reports
         public void Run(string outputFileName)
         {
             Console.WriteLine("Running Advancement Check");
-            foreach (var scout in this.Scouts)
+            foreach (var scout in this.Scouts.Where(s => !string.Equals(s.Patrol, "Inactive", StringComparison.OrdinalIgnoreCase)))
             {
                 // Eagle implies Life implies Star implies 1C implies 2C implies Tenderfoot implies Scout
                 if (scout.Eagle.Earned && !scout.Life.Earned)

--- a/advancement-chart/Reports/AdvancementReport.cs
+++ b/advancement-chart/Reports/AdvancementReport.cs
@@ -146,7 +146,7 @@ namespace advancementchart.Reports
                 }
                 WriteLine(body, string.Empty);
 
-                foreach (var scout in this.Scouts)
+                foreach (var scout in this.Scouts.Where(s => !string.Equals(s.Patrol, "Inactive", StringComparison.OrdinalIgnoreCase)))
                 {
                     scout.AllocateMeritBadges();
 

--- a/advancement-chart/Reports/EagleReport.cs
+++ b/advancement-chart/Reports/EagleReport.cs
@@ -118,7 +118,7 @@ namespace advancementchart.Reports
                 File.Delete(outputFileName);
 
 
-            List<TroopMember> scouts = this.Scouts.Where(m => m.FirstClass.Earned && !m.Eagle.Earned).ToList();
+            List<TroopMember> scouts = this.Scouts.Where(m => m.FirstClass.Earned && !m.Eagle.Earned && !string.Equals(m.Patrol, "Inactive", StringComparison.OrdinalIgnoreCase)).ToList();
             if (!scouts.Any())
             {
                 return;

--- a/advancement-chart/Reports/IndividualReport.cs
+++ b/advancement-chart/Reports/IndividualReport.cs
@@ -29,7 +29,7 @@ namespace advancementchart.Reports
                 Dictionary<string, ExcelWorksheet> patrolSheets = new Dictionary<string, ExcelWorksheet>();
 
                 // Figure out Patrols
-                Dictionary<string, List<TroopMember>> patrols = Scouts.GroupBy(s => s.Patrol).ToDictionary(g => g.Key, g => g.ToList());
+                Dictionary<string, List<TroopMember>> patrols = Scouts.Where(s => !string.Equals(s.Patrol, "Inactive", StringComparison.OrdinalIgnoreCase)).GroupBy(s => s.Patrol).ToDictionary(g => g.Key, g => g.ToList());
                 if (patrols.Keys.Count > 1)
                 {
                     foreach (string patrolName in patrols.Keys.OrderBy(s => s))
@@ -39,7 +39,7 @@ namespace advancementchart.Reports
                 }
 
                 // Collect data (and also add individual Scout sheets)
-                foreach (var scout in Scouts)
+                foreach (var scout in Scouts.Where(s => !string.Equals(s.Patrol, "Inactive", StringComparison.OrdinalIgnoreCase)))
                 {
                     // Skip Scouts that have already earned First Class
                     if (!scout.FirstClass.Earned)

--- a/advancement-chart/Reports/TroopCheckList.cs
+++ b/advancement-chart/Reports/TroopCheckList.cs
@@ -11,7 +11,7 @@ namespace advancementchart.Reports
 {
     public class TroopCheckList : IReport
     {
-        private const int CheckboxColumns = 25;
+        private const int CheckboxColumns = 10;
         private const double CheckboxColumnWidth = 2.7;
 
         public TroopCheckList(List<TroopMember> scouts)
@@ -32,7 +32,7 @@ namespace advancementchart.Reports
             using (var package = new ExcelPackage(fi))
             {
                 var wks = package.Workbook.Worksheets.Add("Troop Checklist");
-                wks.Cells.Style.Font.Size += 2;
+                wks.Cells.Style.Font.Size += 4;
 
                 wks.PrinterSettings.Orientation = eOrientation.Landscape;
                 wks.PrinterSettings.FitToPage = true;
@@ -41,7 +41,7 @@ namespace advancementchart.Reports
 
                 // Header row with left/bottom/right borders, 4x height
                 int row = 1;
-                wks.Row(row).Height = wks.DefaultRowHeight * 4;
+                wks.Row(row).Height = wks.DefaultRowHeight * 8;
                 for (int col = 2; col <= 1 + CheckboxColumns; col++)
                 {
                     wks.Cells[row, col].Style.Border.Left.Style = ExcelBorderStyle.Thin;

--- a/advancement-chart/Reports/TroopGuideReport.cs
+++ b/advancement-chart/Reports/TroopGuideReport.cs
@@ -56,7 +56,7 @@ namespace advancementchart.Reports
 
                 int taLastRow = taHeaderRow;
 
-                foreach (TroopMember scout in Scouts.Where(s => s.FirstClass.Earned == false).OrderBy(s => s.LastName).ThenBy(s => s.FirstName))
+                foreach (TroopMember scout in Scouts.Where(s => s.FirstClass.Earned == false && !string.Equals(s.Patrol, "Inactive", StringComparison.OrdinalIgnoreCase)).OrderBy(s => s.LastName).ThenBy(s => s.FirstName))
                 {
                     taCell.Row++;
                     taCell.ColumnNumber = 1;

--- a/advancement-chart/Reports/TroopReport.cs
+++ b/advancement-chart/Reports/TroopReport.cs
@@ -516,7 +516,7 @@ namespace advancementchart.Reports
 
                 string patrol = string.Empty;
 
-                foreach (var patrolScouts in Scouts.GroupBy(s => s.Patrol, s => s, (p, s) => s).OrderBy(s => s.Min(a => a.Scout.DateEarned.HasValue ? a.Scout.DateEarned : DateTime.Now)))
+                foreach (var patrolScouts in Scouts.Where(s => !string.Equals(s.Patrol, "Inactive", StringComparison.OrdinalIgnoreCase)).GroupBy(s => s.Patrol, s => s, (p, s) => s).OrderBy(s => s.Min(a => a.Scout.DateEarned.HasValue ? a.Scout.DateEarned : DateTime.Now)))
                 {
                     foreach (var scout in patrolScouts.OrderBy(s => s.Scout.DateEarned.HasValue ? s.Scout.DateEarned : DateTime.Now).ThenBy(s => s.LastName).ThenBy(s => s.FirstName))
                     {


### PR DESCRIPTION
## Summary
- Reduce TroopCheckList checkbox columns from 25 to 10
- Increase TroopCheckList font size by another 2 points (4 total over default)
- Double TroopCheckList header row height from 4x to 8x default
- Filter out Inactive patrol from all 6 remaining reports (TroopReport, IndividualReport, EagleReport, TroopGuideReport, AdvancementReport, AdvancementCheck)
- Add TroopCheckList to README output descriptions

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] All 9 TroopCheckList tests pass
- [x] Full test suite passes (337 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)