### PR TITLE
Add missing merit badges and update Citizenship in Society window

### DIFF
--- a/advancement-chart.tests/Model/EagleMeritBadgeRequirementTest.cs
+++ b/advancement-chart.tests/Model/EagleMeritBadgeRequirementTest.cs
@@ -20,9 +20,9 @@ namespace advancement_chart.tests.Model
         }
 
         [Fact]
-        public void Constructor_Required14_AfterCutover()
+        public void Constructor_Required14_DuringCitSocietyWindow()
         {
-            // Current date is past July 2022
+            // Required is 14 while Citizenship in Society is active (2022-07-01 to 2026-12-31)
             var rank = CreateRank();
             var req = new EagleMeritBadgeRequirement("3", "desc", rank);
             Assert.Equal(14, req.Required);
@@ -145,11 +145,11 @@ namespace advancement_chart.tests.Model
         }
 
         [Fact]
-        public void Elective_Is7_AfterCutover()
+        public void Elective_Is7_DuringCitSocietyWindow()
         {
             var rank = CreateRank();
             var req = new EagleMeritBadgeRequirement("3", "desc", rank);
-            // Total=21, Required=14, so Elective=7
+            // Total=21, Required=14 during Cit in Society window (2022-07-01 to 2026-12-31), so Elective=7
             Assert.Equal(7, req.Elective);
         }
     }

--- a/advancement-chart.tests/Model/MeritBadgeTest.cs
+++ b/advancement-chart.tests/Model/MeritBadgeTest.cs
@@ -90,9 +90,9 @@ namespace advancement_chart.tests.Model
         }
 
         [Fact]
-        public void GetEagleRequired_ContainsCitSociety_AfterCutover()
+        public void GetEagleRequired_ContainsCitSociety_DuringWindow()
         {
-            // Since current date is past 2022-07-01
+            // Citizenship in Society is Eagle-required between 2022-07-01 and 2026-12-31
             var required = MeritBadge.GetEagleRequired();
             Assert.Contains("Citizenship in Society", required);
         }
@@ -189,9 +189,9 @@ namespace advancement_chart.tests.Model
         }
 
         [Fact]
-        public void BsaMeritBadgeIds_Contains161Badges()
+        public void BsaMeritBadgeIds_Contains165Badges()
         {
-            Assert.Equal(161, MeritBadge.BsaMeritBadgeIds.Count);
+            Assert.Equal(165, MeritBadge.BsaMeritBadgeIds.Count);
         }
 
         [Fact]

--- a/advancement-chart/Model/EagleMeritBadgeRequirement.cs
+++ b/advancement-chart/Model/EagleMeritBadgeRequirement.cs
@@ -7,6 +7,7 @@ namespace advancementchart.Model
     public class EagleMeritBadgeRequirement : MeritBadgeRequirement
     {
         public static readonly DateTime CitSocietyCutover = new DateTime(2022, 7, 1);
+        public static readonly DateTime CitSocietyEnd = new DateTime(2026, 12, 31);
 
         protected EagleMeritBadgeRequirement()
             : base()
@@ -15,13 +16,13 @@ namespace advancementchart.Model
         public EagleMeritBadgeRequirement(string name, string description, Rank rank, string version = "2016", string handbookPages = "", DateTime? earned = null)
             : base(name: name, description: description, rank: rank, required: 14, total: 21, version: version, handbookPages: handbookPages)
         {
-            if (DateTime.Now < CitSocietyCutover)
+            if (DateTime.Now >= CitSocietyCutover && DateTime.Now <= CitSocietyEnd)
             {
-                this.Required = 13;
+                this.Required = 14;
             }
             else
             {
-                this.Required = 14;
+                this.Required = 13;
             }
         }
 

--- a/advancement-chart/Model/MeritBadge.cs
+++ b/advancement-chart/Model/MeritBadge.cs
@@ -66,7 +66,8 @@ namespace advancementchart.Model
                 "Hiking",
                 "Cycling"
             };
-            if (DateTime.Now >= EagleMeritBadgeRequirement.CitSocietyCutover)
+            if (DateTime.Now >= EagleMeritBadgeRequirement.CitSocietyCutover
+                && DateTime.Now <= EagleMeritBadgeRequirement.CitSocietyEnd)
             {
                 eagleRequired.Add("Citizenship in Society");
             }
@@ -235,7 +236,11 @@ namespace advancementchart.Model
             {"Animation", "158"},
             {"Exploration", "159"},
             {"Citizenship in Society", "160"},
-            {"Healthcare Professions", "161"}
+            {"Healthcare Professions", "161"},
+            {"Automotive Maintenance", "162"},
+            {"Multisport", "163"},
+            {"Artificial Intelligence", "164"},
+            {"Cybersecurity", "165"}
         };
 
         protected MeritBadge()


### PR DESCRIPTION
## Summary
- Add 4 missing current merit badges to `BsaMeritBadgeIds`: Automotive Maintenance (162), Multisport (163), Artificial Intelligence (164), Cybersecurity (165)
- Update Citizenship in Society Eagle requirement to apply only during the 2022-07-01 to 2026-12-31 window, reverting required count from 14 to 13 after the window closes
- Update tests to reflect new badge count (165) and the Cit in Society requirement window

## Test plan
- [x] All 322 existing tests pass
- [ ] Verify new badges can be constructed (e.g., `new MeritBadge("Automotive Maintenance", "2024")`)
- [ ] Verify Citizenship in Society is currently included in Eagle requirements (today is within the window)

[cc](https://claude.com/claude-code)