### PR TITLE
Fix test host crash, rename Indian Lore, fix palm parsing

### DIFF
--- a/advancement-chart.tests/ProgramTest.cs
+++ b/advancement-chart.tests/ProgramTest.cs
@@ -9,6 +9,7 @@ using advancement_chart;
 
 namespace advancement_chart.tests
 {
+    [Collection("ReportTests")]
     public class ProgramTest : IDisposable
     {
         private readonly List<string> _tempFiles = new List<string>();

--- a/advancement-chart.tests/Reports/AdvancementCheckTest.cs
+++ b/advancement-chart.tests/Reports/AdvancementCheckTest.cs
@@ -8,6 +8,7 @@ using advancement_chart.tests.Helpers;
 
 namespace advancement_chart.tests.Reports
 {
+    [Collection("ReportTests")]
     public class AdvancementCheckTest
     {
         private string CaptureStdErr(Action action)

--- a/advancement-chart.tests/Reports/AdvancementReportTest.cs
+++ b/advancement-chart.tests/Reports/AdvancementReportTest.cs
@@ -12,6 +12,7 @@ using advancement_chart.tests.Helpers;
 
 namespace advancement_chart.tests.Reports
 {
+    [Collection("ReportTests")]
     public class AdvancementReportTest : IDisposable
     {
         private readonly string _tempFile;

--- a/advancement-chart.tests/Reports/EagleReportTest.cs
+++ b/advancement-chart.tests/Reports/EagleReportTest.cs
@@ -10,6 +10,7 @@ using advancement_chart.tests.Helpers;
 
 namespace advancement_chart.tests.Reports
 {
+    [Collection("ReportTests")]
     public class EagleReportTest : IDisposable
     {
         private readonly string _tempFile;

--- a/advancement-chart.tests/Reports/IndividualReportTest.cs
+++ b/advancement-chart.tests/Reports/IndividualReportTest.cs
@@ -9,6 +9,7 @@ using advancement_chart.tests.Helpers;
 
 namespace advancement_chart.tests.Reports
 {
+    [Collection("ReportTests")]
     public class IndividualReportTest : IDisposable
     {
         private readonly string _tempFile;

--- a/advancement-chart.tests/Reports/TroopCheckListTest.cs
+++ b/advancement-chart.tests/Reports/TroopCheckListTest.cs
@@ -9,6 +9,7 @@ using advancement_chart.tests.Helpers;
 
 namespace advancement_chart.tests.Reports
 {
+    [Collection("ReportTests")]
     public class TroopCheckListTest : IDisposable
     {
         private readonly string _tempFile;

--- a/advancement-chart.tests/Reports/TroopGuideReportTest.cs
+++ b/advancement-chart.tests/Reports/TroopGuideReportTest.cs
@@ -10,6 +10,7 @@ using advancement_chart.tests.Helpers;
 
 namespace advancement_chart.tests.Reports
 {
+    [Collection("ReportTests")]
     public class TroopGuideReportTest : IDisposable
     {
         private readonly string _tempFile;

--- a/advancement-chart.tests/Reports/TroopReportTest.cs
+++ b/advancement-chart.tests/Reports/TroopReportTest.cs
@@ -10,6 +10,7 @@ using advancement_chart.tests.Helpers;
 
 namespace advancement_chart.tests.Reports
 {
+    [Collection("ReportTests")]
     public class TroopReportTest : IDisposable
     {
         private readonly string _tempFile;

--- a/advancement-chart.tests/advancement-chart.tests.csproj
+++ b/advancement-chart.tests/advancement-chart.tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)/test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />

--- a/advancement-chart.tests/test.runsettings
+++ b/advancement-chart.tests/test.runsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <PANGOCAIRO_BACKEND>fontconfig</PANGOCAIRO_BACKEND>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/advancement-chart/Model/MeritBadge.cs
+++ b/advancement-chart/Model/MeritBadge.cs
@@ -139,7 +139,7 @@ namespace advancementchart.Model
             {"Hiking", "061"},
             {"Home Repairs", "062"},
             {"Horsemanship", "063"},
-            {"Indian Lore", "064"},
+            {"American Indian Culture", "064"},
             {"Insect Study", "065"},
             {"Journalism", "066"},
             {"Landscape Architecture", "067"},

--- a/advancement-chart/Program.cs
+++ b/advancement-chart/Program.cs
@@ -234,7 +234,7 @@ namespace advancement_chart
                                     break;
                                 case "Award Requirement":
                                     var palmName = subtype.Substring(0, subtype.LastIndexOf("#") - 1).Trim();
-                                    var requirementNumber = subtype.Substring(subtype.LastIndexOf("#") + 1).Trim();
+                                    var requirementNumber = subtype.Substring(subtype.LastIndexOf("#") + 1).Trim().TrimEnd('.');
                                     // Console.WriteLine($"Found '{palmName}' and '{requirementNumber}' in '{subtype}'");
                                     if (!string.IsNullOrWhiteSpace(palmName) && !string.IsNullOrWhiteSpace(requirementNumber))
                                     {


### PR DESCRIPTION
## Summary
- Serialize all report test classes and `ProgramTest` into a shared `[Collection("ReportTests")]` xUnit collection to prevent concurrent `libgdiplus`/Pango native calls that crashed the test host process on macOS
- Add `PANGOCAIRO_BACKEND=fontconfig` via `test.runsettings` as additional Pango crash mitigation
- Rename "Indian Lore" to "American Indian Culture" (BSA badge rename, retains ID 064)
- Fix palm award requirement parsing: strip trailing periods from requirement numbers (e.g., `3.` → `3`) so they match the Palm model's requirement names

## Test plan
- [x] All 402 tests pass with no crash (`dotnet test` completes cleanly)
- [ ] Verify palm requirement warnings no longer appear when loading CSV data with trailing-period requirement numbers
- [ ] Verify `new MeritBadge("American Indian Culture", "2024")` succeeds and `new MeritBadge("Indian Lore", "2024")` throws

[cc](https://claude.com/claude-code)