### PR TITLE
Seed scouts from the roster so all registered scouts appear

### DIFF
--- a/advancement-chart.tests/ProgramTest.cs
+++ b/advancement-chart.tests/ProgramTest.cs
@@ -293,14 +293,68 @@ namespace advancement_chart.tests
         }
 
         [Fact]
-        public void LoadPatrolLookup_UnknownScout_Ignored()
+        public void LoadPatrolLookup_RosterScoutNotInAdvancement_IsSeeded()
         {
-            string csv = "BSA Member ID,Nickname,Patrol Name,DOB\n" +
-                          "999,Nobody,Hawks,2008-06-15";
+            // A scout on the roster but with no advancement records must still be
+            // added (seeded), otherwise they would never appear in any report.
+            string csv = "BSA Member ID,First Name,Last Name,Nickname,Patrol Name,DOB\n" +
+                          "999,Diana,Wilson,,Hawks,2010-06-15";
             var path = CreateTempCsv(csv);
 
             Program.LoadPatrolLookup(path, _scouts);
-            // Should not throw, just skip unknown scouts
+
+            Assert.Single(_scouts);
+            Assert.Equal("999", _scouts[0].BsaMemberId);
+            Assert.Equal("Diana", _scouts[0].FirstName);
+            Assert.Equal("Wilson", _scouts[0].LastName);
+            Assert.Equal("Hawks", _scouts[0].Patrol);
+            Assert.Equal(new DateTime(2010, 6, 15), _scouts[0].DateOfBirth);
+        }
+
+        [Fact]
+        public void LoadPatrolLookup_SeededScout_WithoutPatrol_DefaultsToUnassigned()
+        {
+            // A seeded scout with no patrol on the roster keeps the constructor's
+            // "Unassigned" default rather than an empty patrol.
+            string csv = "BSA Member ID,First Name,Last Name,Nickname,Patrol Name,DOB\n" +
+                          "999,Diana,Wilson,,,";
+            var path = CreateTempCsv(csv);
+
+            Program.LoadPatrolLookup(path, _scouts);
+
+            Assert.Single(_scouts);
+            Assert.Equal("Unassigned", _scouts[0].Patrol);
+        }
+
+        [Fact]
+        public void LoadPatrolLookup_BlankMemberId_IsSkipped()
+        {
+            // Placeholder/blank roster rows (no member ID) must not create scouts.
+            string csv = "BSA Member ID,First Name,Last Name,Nickname,Patrol Name,DOB\n" +
+                          ",,,,,";
+            var path = CreateTempCsv(csv);
+
+            Program.LoadPatrolLookup(path, _scouts);
+
+            Assert.Empty(_scouts);
+        }
+
+        [Fact]
+        public void LoadPatrolLookup_ExistingScout_NotDuplicatedBySeeding()
+        {
+            // A scout already loaded from advancement must be enriched, not duplicated,
+            // when the same member ID appears on the roster.
+            _scouts.Add(new TroopMember("123", "John", "", "Doe"));
+
+            string csv = "BSA Member ID,First Name,Last Name,Nickname,Patrol Name,DOB\n" +
+                          "123,John,Doe,Johnny,Hawks,2008-06-15";
+            var path = CreateTempCsv(csv);
+
+            Program.LoadPatrolLookup(path, _scouts);
+
+            Assert.Single(_scouts);
+            Assert.Equal("Johnny", _scouts[0].NickName);
+            Assert.Equal("Hawks", _scouts[0].Patrol);
         }
 
         [Fact]

--- a/advancement-chart/Program.cs
+++ b/advancement-chart/Program.cs
@@ -77,6 +77,8 @@ namespace advancement_chart
                     csvReader.ReadHeader();
 
                     int memberIdIndex = csvReader.GetFieldIndex(name: "BSA Member ID");
+                    int firstNameIndex = csvReader.GetFieldIndex(name: "First Name", isTryGet: true);
+                    int lastNameIndex = csvReader.GetFieldIndex(name: "Last Name", isTryGet: true);
                     int nicknameIndex = csvReader.GetFieldIndex(name: "Nickname");
                     int patrolNameIndex = csvReader.GetFieldIndex(name: "Patrol Name");
                     int dobIndex = csvReader.GetFieldIndex(name: "DOB");
@@ -84,31 +86,44 @@ namespace advancement_chart
                     while (csvReader.Read())
                     {
                         string id = csvReader.GetField(memberIdIndex);
-                        TroopMember scout = scouts.FirstOrDefault(tm => tm.BsaMemberId == id);
-                        if (scout != null)
+                        if (string.IsNullOrWhiteSpace(id))
                         {
-                            string nickname = csvReader.GetField(nicknameIndex);
-                            if (!string.IsNullOrWhiteSpace(nickname))
+                            // Skip blank/placeholder roster rows (e.g. an empty line).
+                            continue;
+                        }
+                        TroopMember scout = scouts.FirstOrDefault(tm => tm.BsaMemberId == id);
+                        if (scout == null)
+                        {
+                            // Seed scouts who are on the roster but have no advancement
+                            // records, so every registered scout still appears in the reports.
+                            string firstName = firstNameIndex >= 0 ? csvReader.GetField(firstNameIndex) : "";
+                            string lastName = lastNameIndex >= 0 ? csvReader.GetField(lastNameIndex) : "";
+                            scout = new TroopMember(memberId: id, firstName: firstName, middleName: "", lastName: lastName);
+                            scouts.Add(scout);
+                            Console.WriteLine($"Adding roster-only record for {firstName} {lastName}.");
+                        }
+
+                        string nickname = csvReader.GetField(nicknameIndex);
+                        if (!string.IsNullOrWhiteSpace(nickname))
+                        {
+                            scout.NickName = nickname;
+                        }
+                        string patrol = csvReader.GetField(patrolNameIndex);
+                        if (!string.IsNullOrWhiteSpace(patrol))
+                        {
+                            scout.Patrol = patrol;
+                        }
+                        string dob = csvReader.GetField(dobIndex);
+                        if (!string.IsNullOrWhiteSpace(dob))
+                        {
+                            DateTime dobDate;
+                            if (DateTime.TryParse(dob, out dobDate))
                             {
-                                scout.NickName = nickname;
-                            }
-                            string patrol = csvReader.GetField(patrolNameIndex);
-                            if (!string.IsNullOrWhiteSpace(patrol))
-                            {
-                                scout.Patrol = patrol;
-                            }
-                            string dob = csvReader.GetField(dobIndex);
-                            if (!string.IsNullOrWhiteSpace(dob))
-                            {
-                                DateTime dobDate;
-                                if (DateTime.TryParse(dob, out dobDate))
+                                if (dobDate.Year < 1990 || dobDate > DateTime.Now)
                                 {
-                                    if (dobDate.Year < 1990 || dobDate > DateTime.Now)
-                                    {
-                                        Console.Error.WriteLine($"WARNING: Suspicious DOB '{dob}' for {scout.DisplayName}");
-                                    }
-                                    scout.DateOfBirth = dobDate;
+                                    Console.Error.WriteLine($"WARNING: Suspicious DOB '{dob}' for {scout.DisplayName}");
                                 }
+                                scout.DateOfBirth = dobDate;
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Scouts with no advancement records were absent from every report. Reports are built from the advancement export, so `Program.LoadFile` only ever created a `TroopMember` when a scout had at least one advancement row; `Program.LoadPatrolLookup` (which reads the roster `scouts.csv`) only *enriched* existing scouts. A registered scout with no advancement yet — e.g. a newly joined scout — was therefore never added.

`LoadPatrolLookup` now creates a `TroopMember` for any roster member ID not already loaded, then enriches it (nickname / patrol / DOB) as before.

### Details
- Blank member-id rows (placeholder/blank lines) are skipped.
- The new First/Last Name lookups use the non-throwing `GetFieldIndex(..., isTryGet: true)` overload, so rosters without those columns still work.
- Seeded scouts keep the constructor's `"Unassigned"` patrol default — the same state advancement-loaded scouts with no patrol already fall into — so no report path sees a new case. They render with `NoRank` and are correctly excluded from the Eagle report (First Class and above only).

## Testing
- Rewrote the obsolete `LoadPatrolLookup_UnknownScout_Ignored` into `_IsSeeded`; added tests for the Unassigned-patrol default, blank-id skipping, and that an existing scout is enriched rather than duplicated.
- Full suite: **418 passed, 0 failed**.
- Real export end-to-end: 37 advancement scouts + **1 roster-only seed** = 38 total (previously 37), exit 0, no warnings — verified with aggregate counts only (no PII surfaced).

No tracked GitHub issue.

[cc](https://claude.com/claude-code)